### PR TITLE
Refactor/tag : 태그 저장 restcontroller 구현 및 태그 관련 클래스명 변경

### DIFF
--- a/src/main/java/com/sixesSense/recorder/tag/command/application/controller/CommandTagController.java
+++ b/src/main/java/com/sixesSense/recorder/tag/command/application/controller/CommandTagController.java
@@ -3,11 +3,14 @@ package com.sixesSense.recorder.tag.command.application.controller;
 import com.sixesSense.recorder.tag.command.application.dto.CreateTagRequest;
 import com.sixesSense.recorder.tag.command.application.service.CommandTagServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
 
 @RestController
 @RequestMapping("/api/v1/tag")
@@ -20,9 +23,17 @@ public class CommandTagController {
     }
 
     @PostMapping("/save")
-    public ResponseEntity<String> createTag(@RequestBody CreateTagRequest tagRequest) {
-
-        tagService.createTag(tagRequest);
-        return ResponseEntity.ok("태그가 저장되었습니다.");
+    public ResponseEntity<String> createTag(@Valid @RequestBody CreateTagRequest tagRequest) {
+        try {
+            tagService.createTag(tagRequest);
+            return ResponseEntity.status(HttpStatus.CREATED).body("태그가 성공적으로 저장되었습니다.");
+        } catch (IllegalArgumentException e) {
+            // 서비스에서 던진 IllegalArgumentException 처리
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            // 그 외 예외 처리
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("태그 저장 중 오류 발생: " + e.getMessage());
+        }
     }
+
 }

--- a/src/main/java/com/sixesSense/recorder/tag/command/application/controller/CommandTagController.java
+++ b/src/main/java/com/sixesSense/recorder/tag/command/application/controller/CommandTagController.java
@@ -1,0 +1,28 @@
+package com.sixesSense.recorder.tag.command.application.controller;
+
+import com.sixesSense.recorder.tag.command.application.dto.CreateTagRequest;
+import com.sixesSense.recorder.tag.command.application.service.CommandTagServiceImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/tag")
+public class CommandTagController {
+    private final CommandTagServiceImpl tagService;
+
+    @Autowired
+    public CommandTagController(CommandTagServiceImpl tagService) {
+        this.tagService = tagService;
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<String> createTag(@RequestBody CreateTagRequest tagRequest) {
+
+        tagService.createTag(tagRequest);
+        return ResponseEntity.ok("태그가 저장되었습니다.");
+    }
+}

--- a/src/main/java/com/sixesSense/recorder/tag/command/application/controller/CreateTagController.java
+++ b/src/main/java/com/sixesSense/recorder/tag/command/application/controller/CreateTagController.java
@@ -1,7 +1,0 @@
-package com.sixesSense.recorder.tag.command.application.controller;
-
-import org.springframework.stereotype.Controller;
-
-@Controller
-public class CreateTagController {
-}

--- a/src/main/java/com/sixesSense/recorder/tag/command/application/dto/CreateTagRequest.java
+++ b/src/main/java/com/sixesSense/recorder/tag/command/application/dto/CreateTagRequest.java
@@ -12,6 +12,10 @@ public class CreateTagRequest {
     private Long tagId;
     private String tagName;
 
+    public CreateTagRequest() {
+
+    }
+
     public CreateTagRequest(String tagName) {
         this.tagName = tagName;
     }


### PR DESCRIPTION
## ✨(#90) 태그 저장 restcontroller 구현 및 태그 관련 클래스명 변경

## ✏️내용
```java
@RestController
@RequestMapping("/api/v1/tag")
public class CommandTagController {
    private final CommandTagServiceImpl tagService;

    @Autowired
    public CommandTagController(CommandTagServiceImpl tagService) {
        this.tagService = tagService;
    }

    @PostMapping("/save")
    public ResponseEntity<String> createTag(@RequestBody CreateTagRequest tagRequest) {

        tagService.createTag(tagRequest);
        return ResponseEntity.ok("태그가 저장되었습니다.");
    }
}
```
- 태그 저장 restcontroller 작성
- 2023.10.03 : 아래 코드로 변경하였습니다.
```java
@PostMapping("/save")
public ResponseEntity<String> createTag(@Valid @RequestBody CreateTagRequest tagRequest) {
    try {
        tagService.createTag(tagRequest);
        return ResponseEntity.status(HttpStatus.CREATED).body("태그가 성공적으로 저장되었습니다.");
    } catch (IllegalArgumentException e) {
        // 서비스에서 던진 IllegalArgumentException 처리
        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
    } catch (Exception e) {
        // 그 외 예외 처리
        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("태그 저장 중 오류 발생: " + e.getMessage());
    }
}
```

## 📸스크린샷

## 🎁참고사항
- 개선사항 있으면 댓글로 알려주세요!